### PR TITLE
Updated exported functions in index.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { default } from './binary-uuid';
-export * from './binary-uuid';
+export { fromBinaryUUID, toBinaryUUID } from './binary-uuid';


### PR DESCRIPTION
This solves 'Error: Cannot find module 'tslib'' in the build for users that do not have typescript installed globally.
Not exactly when it changed but you can replicate issue using the latest version typescript@4.5.4. Stated version typescript@3.8.3 in package.json works fine. 